### PR TITLE
Properly sort permissions array

### DIFF
--- a/rmq_definitions.py
+++ b/rmq_definitions.py
@@ -21,6 +21,8 @@ def dict_list_key(item):
     """
     if 'vhost' in item and 'name' in item:
         return item['vhost'], item['name']
+    elif 'user' in item and 'vhost' in item:
+        return item['user'], item['vhost']
     elif 'vhost' in item and 'source' in item and 'destination' in item:
         return item['vhost'], item['source'], item['destination']
     for key in {'name', 'user'}:


### PR DESCRIPTION
The permissions array so far is only sorted by `user` because there is no special handling so far. If users have access to multiple vhosts, the ordering becomes unstable because there will be multiple permission entries with the same user. Therefore add a special case for the permissions array that takes `user` as well as `vhost` into account.

BTW: Thank you for this great little tool!